### PR TITLE
chore: update Proxmox app icon to v2 (light.svg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update chart to upstream `v0.18.0`.
 - changed: `app.giantswarm.io` label group was changed to `application.giantswarm.io`
+- Update Proxmox app icon to `https://s.giantswarm.io/app-icons/proxmox/2/light.svg` (replacing the upstream third-party icon).
 
 [Unreleased]: https://github.com/giantswarm/proxmox-csi-plugin-app/tree/main

--- a/helm/proxmox-csi-plugin/Chart.yaml
+++ b/helm/proxmox-csi-plugin/Chart.yaml
@@ -4,7 +4,7 @@ name: proxmox-csi-plugin
 description: Container Storage Interface plugin for Proxmox
 type: application
 home: https://github.com/sergelogvinov/proxmox-csi-plugin
-icon: https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/charts/proxmox-csi-plugin/icon.png
+icon: https://s.giantswarm.io/app-icons/proxmox/2/light.svg
 sources:
   - https://github.com/sergelogvinov/proxmox-csi-plugin
 keywords:

--- a/sync/patches/chart/_chart.yaml.patch
+++ b/sync/patches/chart/_chart.yaml.patch
@@ -1,7 +1,16 @@
 diff --git a/helm/proxmox-csi-plugin/Chart.yaml b/helm/proxmox-csi-plugin/Chart.yaml
-index 55b84ed..7d2bedd 100644
+index 55b84ed..73703b4 100644
 --- a/helm/proxmox-csi-plugin/Chart.yaml
 +++ b/helm/proxmox-csi-plugin/Chart.yaml
+@@ -4,7 +4,7 @@ name: proxmox-csi-plugin
+ description: Container Storage Interface plugin for Proxmox
+ type: application
+ home: https://github.com/sergelogvinov/proxmox-csi-plugin
+-icon: https://raw.githubusercontent.com/sergelogvinov/proxmox-csi-plugin/main/charts/proxmox-csi-plugin/icon.png
++icon: https://s.giantswarm.io/app-icons/proxmox/2/light.svg
+ sources:
+   - https://github.com/sergelogvinov/proxmox-csi-plugin
+ keywords:
 @@ -24,3 +24,6 @@ version: 0.5.5
  # follow Semantic Versioning. They should reflect the version the application is using.
  # It is recommended to use it with quotes.


### PR DESCRIPTION
Replaces the upstream third-party chart icon with the new Giant Swarm shared web-asset:

`https://s.giantswarm.io/app-icons/proxmox/2/light.svg`

The sync-patch source (`sync/patches/chart/_chart.yaml.patch`) is updated to override the upstream icon, so the change survives the next upstream chart sync.

> [!IMPORTANT]
> The new icon file only becomes available once [`web-assets`](https://github.com/giantswarm/web-assets) `v0.32.0` is released and rolled out. Please do not merge before then.

Context: giantswarm/giantswarm#36874
